### PR TITLE
Fix saving 'disable certificate verification'

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -147,7 +147,7 @@ class SettingsController extends Controller{
 		if ($disable_certificate_verification !== null) {
 			$this->appConfig->setAppValue(
 				'disable_certificate_verification',
-				$disable_certificate_verification === 'true' ? 'yes' : ''
+				$disable_certificate_verification === true ? 'yes' : ''
 			);
 		}
 


### PR DESCRIPTION
* Target version: master 

### Summary

The value is never fully equal to 'true', so checking this option is never saved.
Instead it is fully equal to the boolean value true

### Checklist

- [x] Code is properly formatted
- [?] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
